### PR TITLE
Fix the URL to the Enterprise licence

### DIFF
--- a/src/data/tos.mdx
+++ b/src/data/tos.mdx
@@ -9,7 +9,7 @@ The service provider is **Defguard Sp. z o.o.**, with its registered office in S
 #### 2. **Scope of Terms**
 
 These Terms apply exclusively to the provision of license delivery services and email/ticket-based support services.  
-They do not cover the **self-hosted Defguard software or its clients**, which are governed by the Enterprise License available at: [Defguard Enterprise License](https://github.com/DefGuard/defguard/blob/main/src/enterprise/LICENSE.md).  
+They do not cover the **self-hosted Defguard software or its clients**, which are governed by the Enterprise License available at: [Defguard Enterprise License](https://github.com/DefGuard/defguard/blob/main/crates/defguard_core/src/enterprise/LICENSE.md).  
 Purchasing any subscription from this website constitutes acceptance of the Enterprise License.
 
 #### 3. **License Delivery**


### PR DESCRIPTION
The current link is a 404 most likely due to code reorganisation in the `defguard` repo.