### PR TITLE
Add blog post: MFA for WireGuard and NIS2 Directive compliance

### DIFF
--- a/src/content/blog/mfa-wireguard-nis2-compliance.mdx
+++ b/src/content/blog/mfa-wireguard-nis2-compliance.mdx
@@ -98,12 +98,12 @@ Learn more about our approach to **[true, connection-level VPN MFA](https://defg
 
 ## Why Build on the WireGuard® Protocol?
 
-While older protocols like OpenVPN and IPSec have served their purpose, the WireGuard® protocol offers clear, measurable advantages that make it the superior foundation for a modern VPN.
+The WireGuard® protocol has quickly become the preferred foundation for modern VPNs, offering distinct advantages that make it an excellent choice for securing network access. Its design principles deliver superior performance and reliability.
 
-* **Faster VPN Speeds:** WireGuard® is approximately 10x faster than OpenVPN since it operates at the kernel and protocol level, not the application level.
-* **Seamless Roaming:** WireGuard® is designed to handle network changes (like switching from Wi-Fi to cellular) more gracefully, maintaining the connection without interruption.
-* **Lower VPN Latency:** WireGuard® has far lower latency than OpenVPN due to its lightweight design and modern cryptographic protocols.
-* **Instant Connectivity:** WireGuard®‘s handshakes are extremely fast, allowing near-instantaneous connections, unlike OpenVPN which can take several seconds.
+* **Exceptional Speed:** WireGuard® operates efficiently at the kernel and protocol level, leading to significantly faster VPN throughput.
+* **Resilient Connectivity:** Designed for stability, WireGuard® handles network transitions (e.g., switching from Wi-Fi to cellular) seamlessly, maintaining active connections without interruption.
+* **Minimal Latency:** Its lightweight architecture and modern cryptographic stack result in remarkably low latency, enhancing user experience.
+* **Rapid Connection Establishment:** WireGuard®'s efficient handshakes enable near-instantaneous VPN connections, minimizing wait times.
 
 ## Beyond MFA: Defguard’s Broader Cybersecurity Capabilities
 
@@ -119,7 +119,7 @@ Defguard helps organizations manage digital identities across their network infr
 
 SSO functionality is another powerful feature. It simplifies the user experience by allowing employees to use one set of credentials to access multiple applications, reducing password fatigue.
 
-By integrating with external OpenID providers or using the built-in IdP based on the **[OpenID Connect standard](https://docs.defguard.net/features/openid-connect)**, Defguard creates a secure and user-friendly authentication experience.
+By integrating with **[external OpenID providers](https://docs.defguard.net/features/external-openid-providers)** or using the built-in IdP based on the **[OpenID Connect standard](https://docs.defguard.net/features/openid-connect)**, Defguard creates a secure and user-friendly authentication experience.
 
 ### Hardware Key Management
 

--- a/src/content/blog/mfa-wireguard-nis2-compliance.mdx
+++ b/src/content/blog/mfa-wireguard-nis2-compliance.mdx
@@ -1,7 +1,7 @@
 ---
-title: "MFA for WireGuard: How to Meet NIS2 Directive Requirements"
+title: "MFA for WireGuard®: How to Meet NIS2 Directive Requirements"
 publishDate: 2025-10-07
-description: "The NIS2 Directive mandates MFA for VPNs. Learn how to implement true, connection-level Multi-Factor Authentication on WireGuard with Defguard to ensure compliance and top-tier security."
+description: "The NIS2 Directive mandates MFA for VPNs. Learn how to implement true, connection-level Multi-Factor Authentication for VPNs using the WireGuard® protocol with Defguard to ensure compliance and top-tier security."
 author: "Piotr Borkowicz"
 image: "/images/blog/Defguard-nis2-mfa/wireguard-nis2-hero.png"
 ---
@@ -11,98 +11,61 @@ import MfaDiagram from '../../components/MfaDiagram.astro';
 ![Two hands, one on each side, lightly touch a glowing orange point in the center of a dark, abstract network of interconnected blue and orange lights.](/images/blog/Defguard-nis2-mfa/wireguard-nis2-hero.png)
 
 ## Table of Contents
-- [Understanding the NIS2 Directive](#understanding-the-nis2-directive)
-- [The Role of MFA in NIS2 Compliance](#the-role-of-mfa-in-nis2-compliance)
-- [Why Does NIS2 Require MFA for VPN Access?](#why-does-nis2-require-mfa-for-vpn-access)
-- [WireGuard: The Modern VPN That Needs MFA Support](#wireguard-the-modern-vpn-that-needs-mfa-support)
-- [Beyond MFA: Defguard's Broader Cybersecurity Capabilities](#beyond-mfa-defguards-broader-cybersecurity-capabilities)
-- [How Does Defguard Enable MFA for WireGuard?](#how-does-defguard-enable-mfa-for-wireguard)
+- [The Challenge: NIS2 Mandates MFA, but WireGuard® Lacks It](#the-challenge-nis2-mandates-mfa-but-wireguard-lacks-it)
+- [The Solution: How Defguard Enables True MFA for WireGuard®](#the-solution-how-defguard-enables-true-mfa-for-wireguard)
+- [The Difference: Why Defguard’s Connection-Level MFA is Superior](#the-difference-why-defguards-connection-level-mfa-is-superior)
+- [Why Build on the WireGuard® Protocol?](#why-build-on-the-wireguard-protocol)
+- [Beyond MFA: Defguard’s Broader Cybersecurity Capabilities](#beyond-mfa-defguards-broader-cybersecurity-capabilities)
 - [Managing MFA: Key Considerations for Easy Adoption](#managing-mfa-key-considerations-for-easy-adoption)
-- [The Difference: Understanding True Connection-Level VPN MFA](#the-difference-understanding-true-connection-level-vpn-mfa)
 - [Conclusion](#conclusion)
 - [Frequently Asked Questions (FAQ)](#frequently-asked-questions-faq)
 
-Organizations seeking compliance with the NIS2 Directive can leverage Multi-Factor Authentication (MFA), not just as a regulatory checkbox but as a crucial layer of defense in their cybersecurity strategy. In this article, we’ll explore how MFA supports NIS2 compliance, the advantages of implementing MFA in modern Virtual Private Network (VPN) systems like **[WireGuard](https://www.wireguard.com/)**, and how open-source VPN management solutions like **[Defguard](https://defguard.net/)** facilitate MFA integration in WireGuard environments—while also providing functionalities like identity management, Single Sign-On (SSO), and hardware key management.
+Organizations seeking compliance with the NIS2 Directive must implement Multi-Factor Authentication (MFA) as a crucial layer of defense for remote access.
 
-## Understanding the NIS2 Directive
+In this article, we’ll explore the core challenge this presents for teams using VPNs with the **[WireGuard®](https://www.wireguard.com/)** protocol, and how **[Defguard](https://defguard.net/)** provides the definitive solution by enabling true, connection-level MFA.
 
-The NIS2 Directive (Network and Information Security Directive) builds upon its predecessor (NIS Directive) with more stringent requirements aimed at bolstering the cybersecurity resilience of critical infrastructure sectors, including energy, transport, health, and financial services.
+## The Challenge: NIS2 Mandates MFA, but WireGuard® Lacks It
 
-**It mandates that organizations implement stronger security measures to protect networks, systems, and data. A key component of NIS2 is the focus on MFA.**
+The NIS2 Directive (Network and Information Security Directive) builds upon its predecessor with more stringent requirements aimed at bolstering cybersecurity resilience. For remote access, the directive is clear:
 
-MFA provides an additional layer of security by requiring users to present two or more verification factors to access a system. According to the **[2025 Verizon DBIR](https://www.verizon.com/business/resources/Te12/reports/2025-dbir-data-breach-investigations-report.pdf)**, around 60% of all breaches involved the human element, including stolen credentials, making MFA a critical defense against common attack vectors.
+**It mandates that organizations implement stronger security measures to protect networks, systems, and data. A key component of this is the focus on MFA for all access points, including VPNs.**
 
-## The Role of MFA in NIS2 Compliance
+This presents a significant challenge. The WireGuard® protocol has become the foundation for modern, high-performance VPNs due to its speed and simplicity.
 
-Multi-factor authentication is emphasized in the NIS2 Directive for several reasons. First, it helps mitigate the risks associated with compromised passwords. MFA strengthens the security of authentication processes by requiring more than just a password, thus making it more difficult for malicious actors to gain unauthorized access to sensitive systems.
+However, **the WireGuard® protocol itself does not include any native concept or mechanism for Multi-Factor Authentication.** This architectural reality means that a standard VPN built with WireGuard® is not inherently NIS2 compliant for MFA.
 
-For organizations, MFA provides several security advantages:
-* **Strengthening access control:** MFA makes it exponentially harder for attackers to breach systems, even if they manage to steal a user’s password.
-* **Reducing the risk of phishing attacks:** Even if an attacker tricks a user into providing their login credentials, MFA adds another layer of verification that phishing alone cannot bypass.
-* **Mitigating insider threats:** MFA reduces the likelihood that compromised insider credentials will lead to a security breach.
+According to the **[2025 Verizon DBIR](https://www.verizon.com/business/resources/Te12/reports/2025-dbir-data-breach-investigations-report.pdf)**, around 60% of all breaches involved compromised credentials. Relying solely on a WireGuard® key pair—a single factor—leaves a critical security gap that fails to meet the layered defense principle required by NIS2.
 
-## Why Does NIS2 Require MFA for VPN Access?
+## The Solution: How Defguard Enables True MFA for WireGuard®
 
-Many organizations use VPNs (Virtual Private Networks) to allow employees remote access to company resources. This becomes especially critical when employees work from various locations or connect to the corporate network via public or unsecured networks. Traditionally, VPNs provided a secure tunnel between the user and the network, but the increasing sophistication of attacks, including credential stuffing and brute force attacks, has highlighted the need for stronger authentication mechanisms like MFA.
+Defguard is designed specifically to solve this problem by adding a robust, true MFA layer directly on top of the WireGuard® protocol.
 
-As part of the NIS2 Directive, companies relying on VPN infrastructure to manage access to their network will be required to adopt MFA for VPN authentication. This ensures that even if VPN credentials are compromised, unauthorized access will still be difficult to achieve without additional factors, such as a biometric scan or a one-time passcode (OTP).
-
-<MfaDiagram />
-
-## WireGuard: The Modern VPN That Needs MFA Support
-
-While older VPN protocols like OpenVPN and IPSec have served well for many years, modern solutions like WireGuard are becoming more popular due to their speed, simplicity, and security benefits. WireGuard is a newer VPN protocol that offers a streamlined, efficient, and highly secure method for establishing VPN connections.
-
-Some of the benefits of WireGuard over traditional VPN protocols include:
-* **Speed:** WireGuard is lightweight, leading to faster connection times and lower latency compared to older protocols.
-* **Simplicity:** WireGuard uses fewer lines of code, making it easier to audit, manage, and configure, which translates to a lower chance of security vulnerabilities.
-* **Security:** The cryptographic protocols in WireGuard are modern and robust, ensuring that even if vulnerabilities are discovered in older protocols, WireGuard remains resilient.
-
-Given these advantages, many organizations are transitioning to WireGuard to handle their VPN needs. However, ensuring that WireGuard implementations comply with the NIS2 Directive’s MFA requirements is critical. Fortunately, solutions such as Defguard now make it possible to integrate MFA with WireGuard seamlessly.
-
-## Beyond MFA: Defguard’s Broader Cybersecurity Capabilities
-
-While **[Defguard](https://defguard.net/server/)** excels in integrating MFA with WireGuard VPNs, its functionality extends far beyond that. It provides organizations with a comprehensive security management toolkit, making it a powerful solution for various aspects of cybersecurity compliance and management. In addition to MFA, Defguard offers features like:
-
-### Identity Management
-
-Defguard helps organizations manage digital identities across their network infrastructure. With centralized identity management, businesses can control who has access to what systems and resources. This is crucial for compliance with not only NIS2 but other regulations like GDPR. Defguard’s identity management ensures that access permissions are consistent, up-to-date, and secure.
-
-### Single Sign-On (SSO)
-
-SSO functionality is another powerful feature offered by Defguard. Single Sign-On simplifies the user experience by allowing employees to use one set of credentials to access multiple applications and services. This improves security by reducing the number of login credentials users need to remember and manage, while also minimizing the attack surface for cybercriminals who rely on stolen credentials. By integrating SSO with MFA, Defguard creates a secure, user-friendly authentication experience that reduces the risk of compromised credentials and makes compliance with NIS2 easier.
-
-### Hardware Key Management
-
-Another vital feature of Defguard is its ability to manage hardware keys like YubiKeys. **While Defguard offers robust YubiKey management and provisioning for functions like SSH and GPG keys, it's important to note that hardware keys are not currently used as a second factor for the VPN connection flow itself.** This distinction is crucial for understanding the full scope of security features.
-
-## How Does Defguard Enable MFA for WireGuard?
-
-Defguard is designed to enhance WireGuard by adding a true MFA layer and offering additional capabilities like identity management and SSO, helping organizations meet NIS2 compliance.
+It ensures that even if a user's private key is compromised, unauthorized access is blocked by requiring a second factor before the VPN connection is established.
 
 ![Screenshot of the Defguard interface showing options for enforcing Multi-Factor Authentication (MFA), with the "External MFA" option selected.](/images/blog/Defguard-nis2-mfa/MFA-Defguard.png)
 
-Defguard integrates with modern MFA mechanisms directly at the VPN connection level. Once configured, users must provide a second factor in addition to their WireGuard key to establish a connection. Supported methods for the VPN connection include:
+Defguard integrates with modern MFA mechanisms directly at the VPN connection level. Supported methods for the VPN connection include:
 * **Biometric Authentication**
 * **One-Time Passwords (TOTP)**
 * **External IdP/SSO**
 
-This makes managing and deploying MFA with WireGuard straightforward, enabling organizations to meet regulatory requirements while benefiting from WireGuard’s performance and security advantages.
+<MfaDiagram />
 
-## Managing MFA: Key Considerations for Easy Adoption
+This makes managing and deploying MFA for your VPN straightforward, enabling organizations to meet regulatory requirements while benefiting from WireGuard®’s performance advantages.
 
-Implementing MFA requires careful planning and ongoing management to ensure that it doesn't become cumbersome for users or administrators. Here are a few tips to make the adoption of MFA easier:
-* **User Experience:** Choose MFA methods that strike a balance between security and convenience. Biometric factors offer high security and are often preferred for their ease of use.
-* **Security Monitoring:** Once MFA is deployed, continuously monitor its effectiveness. This includes logging authentication attempts and keeping an eye on any suspicious activity.
-* **Regular Audits:** MFA should be audited regularly to ensure that it continues to meet both security and regulatory requirements. This is especially important as new threats emerge or as the organization grows.
+## The Difference: Why Defguard’s Connection-Level MFA is Superior
 
-## The Difference: Understanding True Connection-Level VPN MFA
+The term "VPN MFA" is often used broadly, but its implementation varies significantly. Many solutions apply MFA only at the application layer—for instance, protecting a web panel or the initial client setup.
 
-The term "VPN MFA" is often used broadly, but its implementation varies significantly across the market. Many solutions apply Multi-Factor Authentication only at the application layer, for instance, protecting the login to a web management panel or during the initial client setup. While this offers some security, it leaves a critical gap: **it does not secure the VPN connection itself.**
+While this offers some security, it leaves a critical gap: **it does not secure the VPN connection itself.**
 
-**Defguard's approach is fundamentally different and unique: it is the only solution that enforces true Multi-Factor Authentication directly at the WireGuard® protocol level, before any connection is established.** This architectural distinction means that no traffic can enter your network without first passing an MFA check, providing a superior security posture essential for NIS2 compliance. This ensures protection even if WireGuard private keys are compromised. Learn more about our approach to **[true, connection-level VPN MFA](https://defguard.net/vpn_mfa/)**.
+**Defguard's approach is fundamentally different and unique: it is the only solution that enforces true Multi-Factor Authentication directly at the WireGuard® protocol level, before any connection is established.**
 
-### Defguard's Supported MFA Methods for WireGuard VPN
+This architectural distinction means that no traffic can enter your network without first passing an MFA check, providing a superior security posture essential for NIS2 compliance. This ensures protection even if WireGuard® private keys are compromised.
+
+Learn more about our approach to **[true, connection-level VPN MFA](https://defguard.net/vpn_mfa/)**.
+
+### Defguard's Supported MFA Methods for WireGuard® VPNs
 
 <div class="table-container" style="width: 100%; overflow-x: auto; margin: 2rem auto; max-width: 80ch;">
   <table class="comparison-table" style="width: 100%; border-collapse: collapse; font-size: 0.95rem; table-layout: fixed; border: 1px solid #e0e0e0; border-radius: 8px; overflow: hidden; background: transparent;">
@@ -133,30 +96,69 @@ The term "VPN MFA" is often used broadly, but its implementation varies signific
   </table>
 </div>
 
+## Why Build on the WireGuard® Protocol?
+
+While older protocols like OpenVPN and IPSec have served their purpose, the WireGuard® protocol offers clear, measurable advantages that make it the superior foundation for a modern VPN.
+
+* **Faster VPN Speeds:** WireGuard® is approximately 10x faster than OpenVPN since it operates at the kernel and protocol level, not the application level.
+* **Seamless Roaming:** WireGuard® is designed to handle network changes (like switching from Wi-Fi to cellular) more gracefully, maintaining the connection without interruption.
+* **Lower VPN Latency:** WireGuard® has far lower latency than OpenVPN due to its lightweight design and modern cryptographic protocols.
+* **Instant Connectivity:** WireGuard®‘s handshakes are extremely fast, allowing near-instantaneous connections, unlike OpenVPN which can take several seconds.
+
+## Beyond MFA: Defguard’s Broader Cybersecurity Capabilities
+
+While **[Defguard](https://defguard.net/server/)** excels at integrating MFA with VPNs using the WireGuard® protocol, its functionality extends far beyond that.
+
+It provides a comprehensive security management toolkit for various aspects of compliance and administration. After solving the core MFA problem, you can leverage features like:
+
+### Identity Management
+
+Defguard helps organizations manage digital identities across their network infrastructure. This is crucial for compliance with not only NIS2 but other regulations like GDPR.
+
+### Single Sign-On (SSO)
+
+SSO functionality is another powerful feature. It simplifies the user experience by allowing employees to use one set of credentials to access multiple applications, reducing password fatigue.
+
+By integrating with external OpenID providers or using the built-in IdP based on the **[OpenID Connect standard](https://docs.defguard.net/features/openid-connect)**, Defguard creates a secure and user-friendly authentication experience.
+
+### Hardware Key Management
+
+Another vital feature is the ability to manage hardware keys like YubiKeys.
+
+**While Defguard offers robust YubiKey management for functions like SSH and GPG keys, it's important to note that hardware keys are not currently used as a second factor for the VPN connection flow itself.**
+
+## Managing MFA: Key Considerations for Easy Adoption
+
+Implementing MFA requires careful planning to ensure it doesn't become cumbersome.
+
+* **User Experience:** Choose MFA methods that strike a balance between security and convenience. Biometric factors are often preferred for their ease of use.
+* **Security Monitoring:** Once MFA is deployed, continuously monitor its effectiveness by logging authentication attempts and watching for suspicious activity.
+* **Regular Audits:** MFA should be audited regularly to ensure it continues to meet both security and regulatory requirements.
+
 ## Conclusion
 
-The NIS2 Directive elevates Multi-Factor Authentication from a best practice to a legal necessity for securing VPN access with WireGuard. The path to compliance is direct:
+The NIS2 Directive elevates Multi-Factor Authentication from a best practice to a legal necessity for securing VPN access. The path to compliance for teams using the WireGuard® protocol is direct:
 
 > **Organizations must implement stronger security measures to protect networks, systems, and data, with a key component being the focus on MFA.**
 
-Solutions like Defguard make this straightforward by integrating connection-level MFA directly into your VPN. This provides a comprehensive, regulatory-compliant strategy that combines robust security with identity management to ensure your critical systems remain protected.
+Solutions like Defguard make this straightforward by integrating true, connection-level MFA directly into your VPN. This provides a comprehensive, regulatory-compliant strategy to ensure your critical systems remain protected.
 
 ## Frequently Asked Questions (FAQ)
 
-### Is WireGuard alone sufficient for NIS2 compliance?
-No. The base WireGuard protocol does not include a native MFA mechanism, which is a key technical requirement for access control under the NIS2 Directive.
+### Is a VPN using the WireGuard® protocol alone sufficient for NIS2 compliance?
+No. The base WireGuard® protocol does not include a native MFA mechanism, which is a key technical requirement for access control under the NIS2 Directive.
 
-### What MFA methods does Defguard support for WireGuard VPN connections?
-Defguard supports true, connection-level MFA using Biometrics (on desktop and mobile) and Time-based One-Time Passwords (TOTP) from apps like Google Authenticator. It can also integrate with external SSO providers like Google and Microsoft to enforce their MFA policies for each connection.
+### What MFA methods does Defguard support for WireGuard® VPN connections?
+Defguard supports true, connection-level MFA using Biometrics, Time-based One-Time Passwords (TOTP), and integration with external SSO providers like Google, Microsoft, Okta, and JumpCloud. For a **[full list of supported providers, see our documentation](https://docs.defguard.net/features/external-openid-providers)**.
 
 ### How is Defguard different from other MFA solutions?
-Defguard is the only open-source platform that enforces MFA at the WireGuard protocol level, not just at an application login. This provides a fundamentally higher level of security required for compliance.
+Defguard is the only open-source platform that enforces MFA at the WireGuard® protocol level, not just at an application login. This provides a fundamentally higher level of security required for compliance.
 
 ---
 
 Piotr Borkowicz
 
-Technical Content Marketing Manager, Defguard
+Technical Writer, Defguard
 
 piotr@defguard.net
 
@@ -170,8 +172,8 @@ defguard.net
     "@type": "WebPage",
     "@id": "https://defguard.net/blog/mfa-wireguard-nis2-compliance/"
   },
-  "headline": "Adopting Multi-Factor Authentication (MFA) for WireGuard: A Path to Compliance with the NIS2 Directive",
-  "description": "The NIS2 Directive mandates MFA for VPNs. Learn how to implement Multi-Factor Authentication on WireGuard with Defguard to ensure compliance and top-tier security.",
+  "headline": "MFA for WireGuard®: How to Meet NIS2 Directive Requirements",
+  "description": "The NIS2 Directive mandates MFA for VPNs. Learn how to implement true, connection-level Multi-Factor Authentication on WireGuard® with Defguard to ensure compliance and top-tier security.",
   "image": "https://defguard.net/images/blog/Defguard-nis2-mfa/wireguard-nis2-hero.png",
   "author": { "@type": "Person", "name": "Piotr Borkowicz" },
   "publisher": {
@@ -184,9 +186,9 @@ defguard.net
   "mainEntity": {
     "@type": "FAQPage",
     "mainEntity": [
-      { "@type": "Question", "name": "Is WireGuard alone sufficient for NIS2 compliance?", "acceptedAnswer": { "@type": "Answer", "text": "No. The base WireGuard protocol does not include a native MFA mechanism, which is a key technical requirement for access control under the NIS2 Directive." } },
-      { "@type": "Question", "name": "What MFA methods does Defguard support for WireGuard?", "acceptedAnswer": { "@type": "Answer", "text": "Defguard supports true, connection-level MFA using Biometrics (on desktop and mobile) and Time-based One-Time Passwords (TOTP) from apps like Google Authenticator. It can also integrate with external SSO providers like Google and Microsoft to enforce MFA." } },
-      { "@type": "Question", "name": "How is Defguard different from other MFA solutions?", "acceptedAnswer": { "@type": "Answer", "text": "Defguard is the only open-source platform that enforces MFA at the WireGuard protocol level, not just at an application login. This provides a fundamentally higher level of security required for compliance." } }
+      { "@type": "Question", "name": "Is a VPN using the WireGuard® protocol alone sufficient for NIS2 compliance?", "acceptedAnswer": { "@type": "Answer", "text": "No. The base WireGuard® protocol does not include a native MFA mechanism, which is a key technical requirement for access control under the NIS2 Directive." } },
+      { "@type": "Question", "name": "What MFA methods does Defguard support for WireGuard® VPN connections?", "acceptedAnswer": { "@type": "Answer", "text": "Defguard supports true, connection-level MFA using Biometrics (on desktop and mobile) and Time-based One-Time Passwords (TOTP) from apps like Google Authenticator. It can also integrate with external SSO providers like Google, Microsoft, Okta, and JumpCloud to enforce their MFA policies for each connection." } },
+      { "@type": "Question", "name": "How is Defguard different from other MFA solutions?", "acceptedAnswer": { "@type": "Answer", "text": "Defguard is the only open-source platform that enforces MFA at the WireGuard® protocol level, not just at an application login. This provides a fundamentally higher level of security required for compliance." } }
     ]
   }
 }`}


### PR DESCRIPTION
✅ Zmieniono strukturę całego artykułu, aby od razu przechodził do sedna: Problem (NIS2 i brak MFA w WireGuard®) -> Rozwiązanie (Jak Defguard to robi) -> Wyróżnik (Dlaczego nasze podejście jest lepsze).

✅ Poprawiono całą terminologię techniczną, zamieniając "Wireguard" na oficjalną formę "WireGuard®" i poprawiając nieprecyzyjne sformułowania (np. "środowiska WireGuard").

✅ Wzmocniono argumentację na rzecz WireGuard®, zastępując starą listę nową, bardziej konkretną i techniczną (szybkość, roaming, niskie opóźnienia).

✅ Dodano jasne stwierdzenie problemu na początku artykułu, wyraźnie informując, że protokół WireGuard® sam w sobie nie posiada wbudowanego mechanizmu MFA.

✅ Przeredagowano kluczowe sekcje, w tym "The Difference...", aby unikać sprzeczności z marketingiem ("buzzword") i skupić się na edukowaniu rynku o przewadze MFA na poziomie protokołu.

✅ Dodano nowe linki do dokumentacji, w tym link do pełnej listy wspieranych dostawców SSO w sekcji FAQ oraz link do dokumentacji OpenID Connect w sekcji o SSO.

✅ Zmieniono tytuł autora w podpisie na "Technical Writer", aby wzmocnić merytoryczny i ekspercki charakter publikacji, zgodnie z feedbackiem.

✅Podzielono tekst na dwu-trzy ilniowe akapity dla większe przejrzystości i żeby poprawić UX czytania.