### PR TITLE
Improve navigation UX and CTA consistency

### DIFF
--- a/src/data/footer.json
+++ b/src/data/footer.json
@@ -34,8 +34,8 @@
       },
       {
         "text": "Contact Us",
-        "external": true,
-        "link": "mailto:sales@defguard.net"
+        "external": false,
+        "link": "/book-a-demo/"
       }
     ]
   },

--- a/src/data/nav.json
+++ b/src/data/nav.json
@@ -26,12 +26,12 @@
     "url": null,
     "children": [
       {
-        "display": "Enterprise Features",
-        "url": "https://docs.defguard.net/enterprise/license"
-      },
-      {
         "display": "Compare vs. Fortinet",
         "url": "/defguard-vs-fortinet"
+      },
+      {
+        "display": "Enterprise Features",
+        "url": "https://docs.defguard.net/enterprise/license"
       }
     ]
   },

--- a/src/pages/defguard-vs-fortinet.astro
+++ b/src/pages/defguard-vs-fortinet.astro
@@ -6,7 +6,6 @@ import OrganizationJSONLD from "../scripts/OrganizationJSONLD.astro";
 import TechArticleJSONLD from "../scripts/TechArticleJSONLD.astro";
 import FAQPageJSONLD from "../scripts/FAQPageJSONLD.astro";
 import SidebarNav from "../components/base/SidebarNav.astro";
-import AstroButton from "../components/AstroButton.astro";
 
 const title = "Defguard vs. Fortinet VPN: A Security-First Alternative (2025)";
 const description = "See a detailed comparison of Defguard vs. Fortinet's VPN. Discover how FortiGate's critical vulnerabilities and legacy design create unacceptable risk. Learn why a modern, open-source alternative is more resilient.";
@@ -96,24 +95,6 @@ const faqEntries = [
       <p class="description">
         Fortinet's recurring vulnerabilities are a liability, not a legacy. Switch to Defguard's modern, WireGuard®-based architecture for verifiable security and true post-breach resilience.
         </p>
-        <div class="cta-buttons">
-        <AstroButton
-          link={{
-            href: "/pricing/?utm_source=fortinet-comparison#get-evaluation-license",
-            target: "_self",
-            preload: true,
-          }}
-          text="Get Evaluation License"
-        />
-        <AstroButton
-          link={{
-            href: "/book-a-demo/?utm_source=fortinet-comparison",
-            target: "_self",
-            preload: true,
-          }}
-          text="Contact Sales"
-        />
-      </div>
     </header>
 
     <ProductSection padding="small">

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -152,7 +152,7 @@ const tags = [
         <button
           type="submit"
           class="btn size-normal"
-          onclick="window.location.href='mailto:sales@defguard.net'"
+          onclick="window.location.href='/book-a-demo/'"
         >
           <span>Contact Sales</span>
         </button>

--- a/src/styles/mixins/_typography.scss
+++ b/src/styles/mixins/_typography.scss
@@ -43,7 +43,7 @@
   }
 
   @if $key == "menu" {
-    font-weight: 300;
+    font-weight: 400;
     @include font-scalable(16px);
   }
 


### PR DESCRIPTION
- Increase menu font-weight from 300 to 400 for better readability
- Update Contact Sales and Contact Us links to point to /book-a-demo/
- Reorder Solutions menu items (Compare vs Fortinet first, then Enterprise)
- Remove redundant CTA buttons from Fortinet comparison hero section